### PR TITLE
Q65 & Q37 correct the answers

### DIFF
--- a/aws/aws-quiz.md
+++ b/aws/aws-quiz.md
@@ -293,8 +293,8 @@ FlowLog:
 
 #### Q37. Where is the best place to store database backups on an EC2 instance that is configured as a database server?
 
-- [x] an S3 bucket, synced with the database backups via a script that calls the AWS CLI
-- [ ] EBS volume attached to the instance
+- [ ] an S3 bucket, synced with the database backups via a script that calls the AWS CLI
+- [x] EBS volume attached to the instance
 - [ ] instance attached to the instance
 - [ ] instance storage, with a script that replicates the database backups to another instance in a different availability zone.
 
@@ -543,9 +543,9 @@ aws ec2 start-instances --instance-ids i-0b263919b6498b123
 ![065](https://user-images.githubusercontent.com/33999631/179728393-8a2636ea-04e7-4597-b0cc-8150e2bc91de.png?raw=png)
 
 - [ ] All traffic on all ports is being denied into this instance, which overwrites the HTTP rule and makes it redundant.
-- [x] The instance was launched with the default security group, but there is no way for an administrator to SSH into the instance.
+- [ ] The instance was launched with the default security group, but there is no way for an administrator to SSH into the instance.
       Add another rule that allows for SSH access from a secured source, such as a single IP or a range of managed IP addresses.
-- [ ] There is nothing wrong with this security group rule. Assuming that sg-269afc5e is applied to other resources that are properly
+- [x] There is nothing wrong with this security group rule. Assuming that sg-269afc5e is applied to other resources that are properly
       secured, this rule allows all traffic to pass through that is also assigned security group sg-269afc5e.
 - [ ] All traffic on all ports are allowed into this instance. This exposes the instance to all public internet traffic and
       overwrites the incoming HTTP rule.


### PR DESCRIPTION
about Q37 which is describe you already have a EC2 run as a database backup, so s3 is another service which can hold the backups but in this answer he is telling you what to use in an ec2, so EBS is a persistent storage even if the server is down you can attach this EBS to another EC2 to hold the same data before crash happens

Q65, its asking about the wrong of the third inbound rule and you can obviously connect to the ec2 if needed you can have the SSH opened in the another SG, so there's nothing wrong until the other security group not secure enough and about ssh you could be using a jump box (Bastion host).

## PR Checklist

This PR is ready for review and meets the requirements set out
in [Suggestion how to contribute](CONTRIBUTING.md)

### DOD

- [ ] I have added new quiz{'s}
- [ ] I have added new reference link{'s}
- [ ] I have made small correction/improvements

### Changes / Instructions

_Add instructions to me, please type here, thanks_
